### PR TITLE
동아리 / 학회 모집 공고 수정 기능 구현

### DIFF
--- a/src/main/java/mju/sw/micro/domain/club/api/ClubRecruitmentApi.java
+++ b/src/main/java/mju/sw/micro/domain/club/api/ClubRecruitmentApi.java
@@ -1,5 +1,6 @@
 package mju.sw.micro.domain.club.api;
 
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import mju.sw.micro.domain.club.application.ClubRecruitmentService;
 import mju.sw.micro.domain.club.dto.request.ClubRecruitmentCreateRequest;
+import mju.sw.micro.domain.club.dto.request.ClubRecruitmentUpdateRequest;
 import mju.sw.micro.global.common.response.ApiResponse;
 
 @Tag(name = "동아리 / 학회 모집공고 API", description = "동아리 및 학회의 모집공고를 등록, 수정, 삭제합니다.")
@@ -27,4 +29,11 @@ public class ClubRecruitmentApi {
 	public ApiResponse<String> createClubRecruitment(@Valid @RequestBody ClubRecruitmentCreateRequest request) {
 		return recruitmentService.createClubRecruitment(request.toServiceRequest());
 	}
+
+	@Operation(summary = "동아리 / 학회 모집 공고 수정 요청")
+	@PatchMapping("/recruitment")
+	public ApiResponse<String> updateClubRecruitment(@Valid @RequestBody ClubRecruitmentUpdateRequest request) {
+		return recruitmentService.updateClubRecruitment(request.toServiceRequest());
+	}
+
 }

--- a/src/main/java/mju/sw/micro/domain/club/application/ClubRecruitmentService.java
+++ b/src/main/java/mju/sw/micro/domain/club/application/ClubRecruitmentService.java
@@ -11,25 +11,29 @@ import mju.sw.micro.domain.club.dao.ClubRepository;
 import mju.sw.micro.domain.club.domain.Club;
 import mju.sw.micro.domain.club.domain.ClubRecruitment;
 import mju.sw.micro.domain.club.dto.request.ClubRecruitmentCreateServiceRequest;
+import mju.sw.micro.domain.club.dto.request.ClubRecruitmentUpdateServiceRequest;
 import mju.sw.micro.global.common.response.ApiResponse;
 import mju.sw.micro.global.error.exception.ErrorCode;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ClubRecruitmentService {
 
 	private final ClubRepository clubRepository;
 	private final ClubRecruitmentRepository recruitmentRepository;
 
-	// TODO : @AuthenticationPrincipal에 담겨 있는 사용자가 학생 단체(동아리/학회) 회장 권한을 가지고 있을 경우에만 공고 등록이 가능하도록 한다.
+	// TODO: @AuthenticationPrincipal을 통해 꺼내온 User의 식별자와 Club에서 꺼내온 User의 식별자가 다르면 권한 x => 에러 반환 메소드(checkClubPresident) 구현
+
 	@Transactional
 	public ApiResponse<String> createClubRecruitment(ClubRecruitmentCreateServiceRequest request) {
-		Optional<Club> optionalClub = clubRepository.findById(request.getClubId());
+		Optional<Club> optionalClub = clubRepository.findById(request.clubId());
 
 		if (optionalClub.isEmpty()) {
 			return ApiResponse.withError(ErrorCode.INVALID_CLUB_ID);
 		}
+
+		// TODO : checkClubPresident 메소드 호출
 
 		Club club = optionalClub.get();
 		ClubRecruitment recruitment = request.toEntity();
@@ -40,4 +44,23 @@ public class ClubRecruitmentService {
 		return ApiResponse.ok("학생 단체(동아리/학회) 공고 등록에 성공했습니다.");
 	}
 
+	@Transactional
+	public ApiResponse<String> updateClubRecruitment(ClubRecruitmentUpdateServiceRequest request) {
+		Optional<ClubRecruitment> optionalRecruitment = recruitmentRepository.findById(request.recruitmentId());
+		if (optionalRecruitment.isEmpty()) {
+			return ApiResponse.withError(ErrorCode.INVALID_CLUB_RECRUITMENT_ID);
+		}
+
+		Optional<Club> optionalClub = clubRepository.findById(request.clubId());
+		if (optionalClub.isEmpty()) {
+			return ApiResponse.withError(ErrorCode.INVALID_CLUB_ID);
+		}
+
+		// TODO : checkClubPresident 메소드 호출
+		ClubRecruitment recruitment = optionalRecruitment.get();
+		recruitment.update(request);
+		recruitmentRepository.save(recruitment);
+
+		return ApiResponse.ok("학생 단체(동아리/학회) 공고 수정에 성공했습니다.");
+	}
 }

--- a/src/main/java/mju/sw/micro/domain/club/application/ClubRecruitmentService.java
+++ b/src/main/java/mju/sw/micro/domain/club/application/ClubRecruitmentService.java
@@ -23,8 +23,6 @@ public class ClubRecruitmentService {
 	private final ClubRepository clubRepository;
 	private final ClubRecruitmentRepository recruitmentRepository;
 
-	// TODO: @AuthenticationPrincipal을 통해 꺼내온 User의 식별자와 Club에서 꺼내온 User의 식별자가 다르면 권한 x => 에러 반환 메소드(checkClubPresident) 구현
-
 	@Transactional
 	public ApiResponse<String> createClubRecruitment(ClubRecruitmentCreateServiceRequest request) {
 		Optional<Club> optionalClub = clubRepository.findById(request.clubId());

--- a/src/main/java/mju/sw/micro/domain/club/domain/Club.java
+++ b/src/main/java/mju/sw/micro/domain/club/domain/Club.java
@@ -6,7 +6,6 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -27,7 +26,6 @@ public class Club extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "club_id")
 	private Long id;
 
 	private String establishedYear;

--- a/src/main/java/mju/sw/micro/domain/club/domain/ClubRecruitment.java
+++ b/src/main/java/mju/sw/micro/domain/club/domain/ClubRecruitment.java
@@ -1,6 +1,7 @@
 package mju.sw.micro.domain.club.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -10,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mju.sw.micro.domain.BaseEntity;
+import mju.sw.micro.domain.club.dto.request.ClubRecruitmentUpdateServiceRequest;
 
 @Entity
 @Getter
@@ -24,7 +26,7 @@ public class ClubRecruitment extends BaseEntity {
 
 	private String content;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private Club club;
 
 	@Builder
@@ -39,5 +41,10 @@ public class ClubRecruitment extends BaseEntity {
 
 	public void setClub(Club club) {
 		this.club = club;
+	}
+
+	public void update(ClubRecruitmentUpdateServiceRequest request) {
+		this.title = request.title();
+		this.content = request.content();
 	}
 }

--- a/src/main/java/mju/sw/micro/domain/club/dto/request/ClubRecruitmentCreateServiceRequest.java
+++ b/src/main/java/mju/sw/micro/domain/club/dto/request/ClubRecruitmentCreateServiceRequest.java
@@ -1,39 +1,14 @@
 package mju.sw.micro.domain.club.dto.request;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 import mju.sw.micro.domain.club.domain.ClubRecruitment;
 
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ClubRecruitmentCreateServiceRequest {
-
-	private String title;
-	private String content;
-	private Long clubId;
-
-	@Builder
-	private ClubRecruitmentCreateServiceRequest(String title, String content, Long clubId) {
-		this.title = title;
-		this.content = content;
-		this.clubId = clubId;
-	}
-
-	public static ClubRecruitmentCreateServiceRequest of(String title, String content, Long clubId) {
-		return ClubRecruitmentCreateServiceRequest.builder()
-			.title(title)
-			.content(content)
-			.clubId(clubId)
-			.build();
-	}
+public record ClubRecruitmentCreateServiceRequest(String title, String content, Long clubId) {
 
 	public ClubRecruitment toEntity() {
 		return ClubRecruitment
 			.builder()
-			.title(this.getTitle())
-			.content(this.getContent())
+			.title(title())
+			.content(content())
 			.build();
 	}
 }

--- a/src/main/java/mju/sw/micro/domain/club/dto/request/ClubRecruitmentUpdateRequest.java
+++ b/src/main/java/mju/sw/micro/domain/club/dto/request/ClubRecruitmentUpdateRequest.java
@@ -6,8 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 
-public record ClubRecruitmentCreateRequest(
-	@Schema(description = "모집 공고 제목 (빈 문자열 허용 x)")
+public record ClubRecruitmentUpdateRequest(
+	@Schema(description = "모집 공고 제목")
 	@NotBlank(message = "모집 공고의 제목은 필수 값입니다.")
 	String title,
 
@@ -18,10 +18,14 @@ public record ClubRecruitmentCreateRequest(
 	@JsonProperty("club_id")
 	@Schema(description = "모집 공고를 게시하는 학생 단체의 식별자 (0 이하의 값 허용 x)")
 	@Positive(message = "모집 공고를 게시하는 학생 단체의 식별자는 양수여야 합니다.")
-	Long clubId
-) {
+	Long clubId,
 
-	public ClubRecruitmentCreateServiceRequest toServiceRequest() {
-		return new ClubRecruitmentCreateServiceRequest(title, content, clubId);
+	@JsonProperty("recruitment_id")
+	@Schema(description = "모집 공고의 식별자 (0 이하의 값 허용 x)")
+	@Positive(message = "모집 공고의 식별자는 양수여야 합니다.")
+	Long recruitmentId
+) {
+	public ClubRecruitmentUpdateServiceRequest toServiceRequest() {
+		return new ClubRecruitmentUpdateServiceRequest(title, content, clubId, recruitmentId);
 	}
 }

--- a/src/main/java/mju/sw/micro/domain/club/dto/request/ClubRecruitmentUpdateServiceRequest.java
+++ b/src/main/java/mju/sw/micro/domain/club/dto/request/ClubRecruitmentUpdateServiceRequest.java
@@ -1,0 +1,4 @@
+package mju.sw.micro.domain.club.dto.request;
+
+public record ClubRecruitmentUpdateServiceRequest(String title, String content, Long clubId, Long recruitmentId) {
+}

--- a/src/main/java/mju/sw/micro/global/common/response/ApiResponse.java
+++ b/src/main/java/mju/sw/micro/global/common/response/ApiResponse.java
@@ -12,7 +12,7 @@ import mju.sw.micro.global.error.exception.ErrorCode;
 public class ApiResponse<T> {
 
 	// API 상태 코드
-	private int statusCode;
+	private int code;
 
 	// API 상태
 	private HttpStatus status;
@@ -24,7 +24,7 @@ public class ApiResponse<T> {
 	private T data;
 
 	private ApiResponse(HttpStatus status, String message, T data) {
-		this.statusCode = status.value();
+		this.code = status.value();
 		this.status = status;
 		this.message = message;
 		this.data = data;

--- a/src/main/java/mju/sw/micro/global/error/exception/ErrorCode.java
+++ b/src/main/java/mju/sw/micro/global/error/exception/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
 	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "Request Body를 통해 전달된 값이 유효하지 않습니다."),
 
 	// Club
-	INVALID_CLUB_ID(HttpStatus.BAD_REQUEST, "Request Body를 통해 전달된 학생 단체의 식별자가 유효하지 않습니다.");
+	INVALID_CLUB_ID(HttpStatus.BAD_REQUEST, "Request Body를 통해 전달된 학생 단체의 식별자가 유효하지 않습니다."),
+	INVALID_CLUB_RECRUITMENT_ID(HttpStatus.BAD_REQUEST, "Request Body를 통해 전달된 학생 단체 모집 공고의 식별자가 유효하지 않습니다.");
 
 	// Other Domain
 	// ...

--- a/src/test/java/mju/sw/micro/domain/club/api/ClubRecruitmentApiTest.java
+++ b/src/test/java/mju/sw/micro/domain/club/api/ClubRecruitmentApiTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.MediaType;
 import mju.sw.micro.ApiTestSupporter;
 import mju.sw.micro.domain.club.dto.request.ClubRecruitmentCreateRequest;
 import mju.sw.micro.domain.club.dto.request.ClubRecruitmentCreateServiceRequest;
+import mju.sw.micro.domain.club.dto.request.ClubRecruitmentUpdateRequest;
 import mju.sw.micro.global.common.response.ApiResponse;
 import mju.sw.micro.global.error.exception.ErrorCode;
 
@@ -20,10 +21,10 @@ class ClubRecruitmentApiTest extends ApiTestSupporter {
 
 	@DisplayName("신규 학생단체(동아리/학회) 모집 공고를 등록한다.")
 	@Test
-	void clubRecruitmentApi() throws Exception {
+	void createClubRecruitment() throws Exception {
 		// Given
-		ClubRecruitmentCreateServiceRequest request = ClubRecruitmentCreateServiceRequest.of("title", "content", 1L);
-		ApiResponse expectedApiResponse = ApiResponse.ok("학생 단체(동아리/학회) 공고 등록에 성공했습니다.");
+		ClubRecruitmentCreateServiceRequest request = new ClubRecruitmentCreateServiceRequest("title", "content", 1L);
+		ApiResponse<String> expectedApiResponse = ApiResponse.ok("학생 단체(동아리/학회) 공고 등록에 성공했습니다.");
 
 		// when
 		when(clubRecruitmentService.createClubRecruitment(any())).thenReturn(expectedApiResponse);
@@ -41,9 +42,9 @@ class ClubRecruitmentApiTest extends ApiTestSupporter {
 
 	@DisplayName("신규 학생단체(동아리/학회) 모집 공고를 등록할 때, 요청으로 들어온 학생단체 식별자를 가지는 학생단체가 없을 경우 등록에 실패한다.")
 	@Test
-	void clubRecruitmentApiWithWrongClubId() throws Exception {
+	void createClubRecruitmentWithWrongClubId() throws Exception {
 		// Given
-		ClubRecruitmentCreateRequest request = ClubRecruitmentCreateRequest.of("title", "content", 1L);
+		ClubRecruitmentCreateRequest request = new ClubRecruitmentCreateRequest("title", "content", 1L);
 		when(clubRecruitmentService.createClubRecruitment(any())).thenReturn(
 			ApiResponse.withError(ErrorCode.INVALID_CLUB_ID));
 
@@ -60,9 +61,9 @@ class ClubRecruitmentApiTest extends ApiTestSupporter {
 
 	@DisplayName("신규 학생단체(동아리/학회) 모집 공고을 등록할 때, 제목은 필수 값이다.")
 	@Test
-	void clubRecruitmentApiWithEmptyTitle() throws Exception {
+	void createClubRecruitmentWithEmptyTitle() throws Exception {
 		// Given
-		ClubRecruitmentCreateRequest request = ClubRecruitmentCreateRequest.of("", "content", 1L);
+		ClubRecruitmentCreateRequest request = new ClubRecruitmentCreateRequest("", "content", 1L);
 
 		//when // then
 		mockMvc.perform(
@@ -78,9 +79,9 @@ class ClubRecruitmentApiTest extends ApiTestSupporter {
 
 	@DisplayName("신규 학생단체(동아리/학회) 모집 공고을 등록할 때, 내용은 필수 값이다.")
 	@Test
-	void clubRecruitmentApiWithEmptyContent() throws Exception {
+	void createClubRecruitmentWithEmptyContent() throws Exception {
 		// Given
-		ClubRecruitmentCreateRequest request = ClubRecruitmentCreateRequest.of("title", "", 1L);
+		ClubRecruitmentCreateRequest request = new ClubRecruitmentCreateRequest("title", "", 1L);
 
 		// when // then
 		mockMvc.perform(
@@ -96,9 +97,9 @@ class ClubRecruitmentApiTest extends ApiTestSupporter {
 
 	@DisplayName("신규 학생단체(동아리/학회) 모집 공고을 등록할 때, 모집 공고를 게시하는 학생 단체의 식별자는 양수여야한다.")
 	@Test
-	void clubRecruitmentApiWithNegativeClubId() throws Exception {
+	void createClubRecruitmentWithNegativeClubId() throws Exception {
 		// Given
-		ClubRecruitmentCreateRequest request = ClubRecruitmentCreateRequest.of("title", "content", 0L);
+		ClubRecruitmentCreateRequest request = new ClubRecruitmentCreateRequest("title", "content", 0L);
 
 		// when // then
 		mockMvc.perform(
@@ -110,5 +111,119 @@ class ClubRecruitmentApiTest extends ApiTestSupporter {
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.message").value("Request Body를 통해 전달된 값이 유효하지 않습니다."))
 			.andExpect(jsonPath("$.data").value(" [clubId] -> 모집 공고를 게시하는 학생 단체의 식별자는 양수여야 합니다. 입력된 값: [0] "));
+	}
+
+	@DisplayName("신규 학생단체(동아리/학회) 모집 공고를 수정한다.")
+	@Test
+	void updateClubRecruitment() throws Exception {
+		// Given
+		ClubRecruitmentUpdateRequest request = new ClubRecruitmentUpdateRequest("title", "content", 1L,
+			1L);
+		ApiResponse<String> expectedApiResponse = ApiResponse.ok("학생 단체(동아리/학회) 공고 수정에 성공했습니다.");
+
+		// when
+		when(clubRecruitmentService.updateClubRecruitment(any())).thenReturn(expectedApiResponse);
+
+		// then
+		mockMvc.perform(
+				patch("/api/recruitment")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value(expectedApiResponse.getMessage()));
+	}
+
+	@DisplayName("신규 학생단체(동아리/학회) 모집 공고를 수정할 때, 제목은 필수 값이다.")
+	@Test
+	void updateClubRecruitmentWithEmptyTitle() throws Exception {
+		// Given
+		ClubRecruitmentUpdateRequest request = new ClubRecruitmentUpdateRequest("", "content", 1L, 1L);
+
+		//when // then
+		mockMvc.perform(
+				patch("/api/recruitment")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("Request Body를 통해 전달된 값이 유효하지 않습니다."))
+			.andExpect(jsonPath("$.data").value(" [title] -> 모집 공고의 제목은 필수 값입니다. 입력된 값: [] "));
+	}
+
+	@DisplayName("신규 학생단체(동아리/학회) 모집 공고을 수정할 때, 내용은 필수 값이다.")
+	@Test
+	void updateClubRecruitmentWithEmptyContent() throws Exception {
+		// Given
+		ClubRecruitmentUpdateRequest request = new ClubRecruitmentUpdateRequest("title", "", 1L, 1L);
+
+		// when // then
+		mockMvc.perform(
+				patch("/api/recruitment")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("Request Body를 통해 전달된 값이 유효하지 않습니다."))
+			.andExpect(jsonPath("$.data").value(" [content] -> 모집 공고의 내용은 필수 값입니다. 입력된 값: [] "));
+	}
+
+	@DisplayName("신규 학생단체(동아리/학회) 모집 공고를 수정할 때, 모집 공고를 게시하는 학생 단체의 식별자는 양수여야한다.")
+	@Test
+	void updateClubRecruitmentWithNegativeClubId() throws Exception {
+		// Given
+		ClubRecruitmentUpdateRequest request = new ClubRecruitmentUpdateRequest("title", "content", 0L, 1L);
+
+		// when // then
+		mockMvc.perform(
+				patch("/api/recruitment")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("Request Body를 통해 전달된 값이 유효하지 않습니다."))
+			.andExpect(jsonPath("$.data").value(" [clubId] -> 모집 공고를 게시하는 학생 단체의 식별자는 양수여야 합니다. 입력된 값: [0] "));
+	}
+
+	@DisplayName("신규 학생단체(동아리/학회) 모집 공고를  수정할 때, 요청으로 들어온 학생단체 식별자를 가지는 학생단체가 없을 경우 수정에 실패한다.")
+	@Test
+	void updateClubRecruitmentWithWrongClubId() throws Exception {
+		// Given
+		ClubRecruitmentUpdateRequest request = new ClubRecruitmentUpdateRequest("title", "content", 1L, 1L);
+		when(clubRecruitmentService.updateClubRecruitment(any())).thenReturn(
+			ApiResponse.withError(ErrorCode.INVALID_CLUB_ID));
+
+		// when // then
+		mockMvc.perform(
+				patch("/api/recruitment")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value(INVALID_CLUB_ID.getMessage()));
+	}
+
+	@DisplayName("신규 학생단체(동아리/학회) 모집 공고를 수정할 때, 요청으로 들어온 모집 공고 식별자를 가지는 모집 공고가 없을 경우 등록에 실패한다.")
+	@Test
+	void updateClubRecruitmentWithWrongClubRecruitmentId() throws Exception {
+		// Given
+		ClubRecruitmentUpdateRequest request = new ClubRecruitmentUpdateRequest("title", "content", 1L, 1L);
+		when(clubRecruitmentService.updateClubRecruitment(any())).thenReturn(
+			ApiResponse.withError(ErrorCode.INVALID_CLUB_RECRUITMENT_ID));
+
+		// when // then
+		mockMvc.perform(
+				patch("/api/recruitment")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+			.andExpect(jsonPath("$.message").value(INVALID_CLUB_RECRUITMENT_ID.getMessage()));
 	}
 }


### PR DESCRIPTION
[아래 이슈에 대한 작업]
https://github.com/MJU-MICRO/MICRO_Server/issues/18

[완료 작업 목록]
- Swagger 적용
- 공통 응답 포맷을 통해 일반 응답/ 에러 응답을 일관성 있게 반환할 수 있도록 에러 응답 방법 리팩토링
- 동아리 / 학회 모집 공고 등록 기능 구현
- 동아리 / 학회 모집 공고 등록 기능 구현에 필요한 Repository Layer, Service Layer, Controller Layer에 대한 테스트 코드 작성 완료

[TODO]
동아리 / 학회 모집 공고 삭제 기능 구현