### PR TITLE
회원 정보 조회/수정/삭제 기능 개발

### DIFF
--- a/src/main/java/mju/sw/micro/domain/user/api/AuthApi.java
+++ b/src/main/java/mju/sw/micro/domain/user/api/AuthApi.java
@@ -34,7 +34,7 @@ public class AuthApi {
 	@Operation(summary = "이메일 송신 및 인증 코드 저장")
 	@PostMapping("/email")
 	@ResponseStatus(HttpStatus.OK)
-	public ApiResponse<String> sendEmailAndSaveCode(@Validated @RequestBody EmailSendRequestDto dto) {
+	public ApiResponse<Void> sendEmailAndSaveCode(@Validated @RequestBody EmailSendRequestDto dto) {
 		return authService.sendEmailAndSaveCode(dto);
 	}
 
@@ -48,7 +48,7 @@ public class AuthApi {
 	@Operation(summary = "회원가입")
 	@PostMapping("/sign-up")
 	@ResponseStatus(HttpStatus.CREATED)
-	public ApiResponse<String> signUp(@Validated @RequestPart("dto") SignUpRequestDto dto,
+	public ApiResponse<Void> signUp(@Validated @RequestPart("dto") SignUpRequestDto dto,
 		@RequestPart(value = "file", required = false) MultipartFile imageFile) {
 		return authService.signUp(dto, imageFile);
 	}

--- a/src/main/java/mju/sw/micro/domain/user/api/UserApi.java
+++ b/src/main/java/mju/sw/micro/domain/user/api/UserApi.java
@@ -3,6 +3,7 @@ package mju.sw.micro.domain.user.api;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -57,5 +58,12 @@ public class UserApi {
 		@RequestPart(value = "file", required = false) MultipartFile imageFile,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		return userService.modifyUserInfo(dto, imageFile, userDetails.getEmail());
+	}
+
+	@Operation(summary = "회원 탈퇴")
+	@DeleteMapping("/my")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Void> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+		return userService.deleteUser(userDetails.getEmail());
 	}
 }

--- a/src/main/java/mju/sw/micro/domain/user/api/UserApi.java
+++ b/src/main/java/mju/sw/micro/domain/user/api/UserApi.java
@@ -34,12 +34,11 @@ public class UserApi {
 	/**
 	 * 로그아웃, AuthApi에 로그아웃을 두지 않은 이유는 로그아웃 할 때는 UserDetails를 이용하기 때문에 토큰이 필요함
 	 * 필터에서 api/auth는 anonymous로 설정되어 있어서 액세스 토큰이 있으면 권한이 있는 사용자이기 때문에 UnAuthorized 됨
-	 *
 	 */
 	@Operation(summary = "로그아웃")
 	@PostMapping("/logout")
 	@ResponseStatus(HttpStatus.OK)
-	public ApiResponse<String> logout(@Validated @RequestBody LogoutRequestDto dto,
+	public ApiResponse<Void> logout(@Validated @RequestBody LogoutRequestDto dto,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		return userService.logout(dto, userDetails);
 	}

--- a/src/main/java/mju/sw/micro/domain/user/api/UserApi.java
+++ b/src/main/java/mju/sw/micro/domain/user/api/UserApi.java
@@ -3,6 +3,7 @@ package mju.sw.micro.domain.user.api;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import mju.sw.micro.domain.user.application.UserService;
 import mju.sw.micro.domain.user.dto.request.LogoutRequestDto;
+import mju.sw.micro.domain.user.dto.response.UserInfoResponseDto;
 import mju.sw.micro.global.common.response.ApiResponse;
 import mju.sw.micro.global.security.CustomUserDetails;
 
@@ -28,9 +30,6 @@ public class UserApi {
 	 * 로그아웃, AuthApi에 로그아웃을 두지 않은 이유는 로그아웃 할 때는 UserDetails를 이용하기 때문에 토큰이 필요함
 	 * 필터에서 api/auth는 anonymous로 설정되어 있어서 액세스 토큰이 있으면 권한이 있는 사용자이기 때문에 UnAuthorized 됨
 	 *
-	 * @param dto
-	 * @param userDetails
-	 * @return
 	 */
 	@Operation(summary = "로그아웃")
 	@PostMapping("/logout")
@@ -38,5 +37,12 @@ public class UserApi {
 	public ApiResponse<String> logout(@Validated @RequestBody LogoutRequestDto dto,
 		@AuthenticationPrincipal CustomUserDetails userDetails) {
 		return userService.logout(dto, userDetails);
+	}
+
+	@Operation(summary = "회원 정보 조회")
+	@GetMapping("/my")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<UserInfoResponseDto> getUserInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
+		return userService.getUserInfo(userDetails.getEmail());
 	}
 }

--- a/src/main/java/mju/sw/micro/domain/user/api/UserApi.java
+++ b/src/main/java/mju/sw/micro/domain/user/api/UserApi.java
@@ -5,16 +5,20 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import mju.sw.micro.domain.user.application.UserService;
 import mju.sw.micro.domain.user.dto.request.LogoutRequestDto;
+import mju.sw.micro.domain.user.dto.request.UserModifyRequestDto;
 import mju.sw.micro.domain.user.dto.response.UserInfoResponseDto;
 import mju.sw.micro.global.common.response.ApiResponse;
 import mju.sw.micro.global.security.CustomUserDetails;
@@ -44,5 +48,14 @@ public class UserApi {
 	@ResponseStatus(HttpStatus.OK)
 	public ApiResponse<UserInfoResponseDto> getUserInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
 		return userService.getUserInfo(userDetails.getEmail());
+	}
+
+	@Operation(summary = "회원 정보 수정")
+	@PutMapping("/my")
+	@ResponseStatus(HttpStatus.OK)
+	public ApiResponse<Void> modifyUserInfo(@Validated @RequestPart("dto") UserModifyRequestDto dto,
+		@RequestPart(value = "file", required = false) MultipartFile imageFile,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		return userService.modifyUserInfo(dto, imageFile, userDetails.getEmail());
 	}
 }

--- a/src/main/java/mju/sw/micro/domain/user/application/AuthService.java
+++ b/src/main/java/mju/sw/micro/domain/user/application/AuthService.java
@@ -76,7 +76,7 @@ public class AuthService {
 		if (!isVerified) {
 			return ApiResponse.withError(ErrorCode.INVALID_TOKEN);
 		}
-		String imageUrl = uploadImage(imageFile).getData();
+		String profileImageUrl = uploadImage(imageFile).getData();
 		User user = User.builder()
 			.email(dto.getEmail())
 			.password(encoder.encode(dto.getPassword()))
@@ -87,7 +87,7 @@ public class AuthService {
 			.phoneNumber(dto.getPhoneNumber())
 			.introduction(dto.getIntroduction())
 			.notification(dto.getNotification())
-			.profileImageUrl(imageUrl)
+			.profileImageUrl(profileImageUrl)
 			.build();
 		user.addRole(Role.ROLE_USER);
 		userRepository.save(user);

--- a/src/main/java/mju/sw/micro/domain/user/application/AuthService.java
+++ b/src/main/java/mju/sw/micro/domain/user/application/AuthService.java
@@ -49,8 +49,8 @@ public class AuthService {
 
 	public ApiResponse<String> sendEmailAndSaveCode(EmailSendRequestDto dto) {
 		String emailCode = CodeUtil.generateRandomCode();
-		mailService.sendMessage(dto.getEmail(), EmailConstants.EMAIL_TITLE,
-			EmailConstants.EMAIL_CONTENT_HTML,
+		mailService.sendMessage(dto.getEmail(), EmailConstants.EMAIL_SIGN_UP_TITLE,
+			EmailConstants.EMAIL_SIGN_UP_CONTENT_HTML,
 			emailCode);
 		String expirationDate = TimeUtil.generateExpiration(EmailConstants.EMAIL_TOKEN_EXPIRATION_TIME);
 		EmailCode code = EmailCode.of(dto.getEmail(), emailCode, EmailConstants.EMAIL_TOKEN_EXPIRATION_TIME,

--- a/src/main/java/mju/sw/micro/domain/user/application/AuthService.java
+++ b/src/main/java/mju/sw/micro/domain/user/application/AuthService.java
@@ -84,11 +84,10 @@ public class AuthService {
 			.nickName(dto.getNickName())
 			.studentId(dto.getStudentId())
 			.major(dto.getMajor())
-			.interest(dto.getInterest())
 			.phoneNumber(dto.getPhoneNumber())
 			.introduction(dto.getIntroduction())
 			.notification(dto.getNotification())
-			.imageUrl(imageUrl)
+			.profileImageUrl(imageUrl)
 			.build();
 		user.addRole(Role.ROLE_USER);
 		userRepository.save(user);

--- a/src/main/java/mju/sw/micro/domain/user/application/AuthService.java
+++ b/src/main/java/mju/sw/micro/domain/user/application/AuthService.java
@@ -47,7 +47,7 @@ public class AuthService {
 	private final JwtService jwtService;
 	private final S3Uploader s3Uploader;
 
-	public ApiResponse<String> sendEmailAndSaveCode(EmailSendRequestDto dto) {
+	public ApiResponse<Void> sendEmailAndSaveCode(EmailSendRequestDto dto) {
 		String emailCode = CodeUtil.generateRandomCode();
 		mailService.sendMessage(dto.getEmail(), EmailConstants.EMAIL_SIGN_UP_TITLE,
 			EmailConstants.EMAIL_SIGN_UP_CONTENT_HTML,
@@ -68,7 +68,7 @@ public class AuthService {
 	}
 
 	@Transactional
-	public ApiResponse<String> signUp(SignUpRequestDto dto, MultipartFile imageFile) {
+	public ApiResponse<Void> signUp(SignUpRequestDto dto, MultipartFile imageFile) {
 		if (userRepository.findByEmail(dto.getEmail()).isPresent()) {
 			return ApiResponse.withError(ErrorCode.ALREADY_SIGN_UP_EMAIL);
 		}

--- a/src/main/java/mju/sw/micro/domain/user/application/UserService.java
+++ b/src/main/java/mju/sw/micro/domain/user/application/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
 			return ApiResponse.withError(ErrorCode.NOT_FOUND);
 		}
 		User user = optionalUser.get();
-		return ApiResponse.ok(
+		return ApiResponse.ok("회원 정보 조회 완료",
 			UserInfoResponseDto.builder()
 				.profileImageUrl(user.getProfileImageUrl())
 				.name(user.getName())

--- a/src/main/java/mju/sw/micro/domain/user/application/UserService.java
+++ b/src/main/java/mju/sw/micro/domain/user/application/UserService.java
@@ -8,9 +8,12 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import mju.sw.micro.domain.user.dao.BlackListTokenRedisRepository;
 import mju.sw.micro.domain.user.dao.RefreshTokenRedisRepository;
+import mju.sw.micro.domain.user.dao.UserRepository;
 import mju.sw.micro.domain.user.domain.BlackListAccessToken;
 import mju.sw.micro.domain.user.domain.RefreshToken;
+import mju.sw.micro.domain.user.domain.User;
 import mju.sw.micro.domain.user.dto.request.LogoutRequestDto;
+import mju.sw.micro.domain.user.dto.response.UserInfoResponseDto;
 import mju.sw.micro.global.common.response.ApiResponse;
 import mju.sw.micro.global.error.exception.ErrorCode;
 import mju.sw.micro.global.security.CustomUserDetails;
@@ -24,6 +27,7 @@ public class UserService {
 	private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 	private final BlackListTokenRedisRepository blackListTokenRedisRepository;
 	private final JwtService jwtService;
+	private final UserRepository userRepository;
 
 	public ApiResponse<String> logout(LogoutRequestDto dto, CustomUserDetails userDetails) {
 		String accessToken = dto.getAccessToken();
@@ -39,5 +43,21 @@ public class UserService {
 		blackListTokenRedisRepository.save(
 			BlackListAccessToken.of(expiration, accessToken, TimeUtil.generateExpiration(expiration)));
 		return ApiResponse.ok("로그아웃 되었습니다.");
+	}
+
+	public ApiResponse<UserInfoResponseDto> getUserInfo(String email) {
+		Optional<User> optionalUser = userRepository.findByEmail(email);
+		if (optionalUser.isEmpty()) {
+			return ApiResponse.withError(ErrorCode.NOT_FOUND);
+		}
+		User user = optionalUser.get();
+		return ApiResponse.ok(
+			UserInfoResponseDto.builder()
+				.profileImageUrl(user.getProfileImageUrl())
+				.name(user.getName())
+				.nickName(user.getNickName())
+				.major(user.getMajor())
+				.introduction(user.getIntroduction())
+				.build());
 	}
 }

--- a/src/main/java/mju/sw/micro/domain/user/application/UserService.java
+++ b/src/main/java/mju/sw/micro/domain/user/application/UserService.java
@@ -2,9 +2,12 @@ package mju.sw.micro.domain.user.application;
 
 import java.util.Optional;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import io.micrometer.common.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 import mju.sw.micro.domain.user.dao.BlackListTokenRedisRepository;
 import mju.sw.micro.domain.user.dao.RefreshTokenRedisRepository;
@@ -13,7 +16,9 @@ import mju.sw.micro.domain.user.domain.BlackListAccessToken;
 import mju.sw.micro.domain.user.domain.RefreshToken;
 import mju.sw.micro.domain.user.domain.User;
 import mju.sw.micro.domain.user.dto.request.LogoutRequestDto;
+import mju.sw.micro.domain.user.dto.request.UserModifyRequestDto;
 import mju.sw.micro.domain.user.dto.response.UserInfoResponseDto;
+import mju.sw.micro.global.adapter.S3Uploader;
 import mju.sw.micro.global.common.response.ApiResponse;
 import mju.sw.micro.global.error.exception.ErrorCode;
 import mju.sw.micro.global.security.CustomUserDetails;
@@ -28,6 +33,8 @@ public class UserService {
 	private final BlackListTokenRedisRepository blackListTokenRedisRepository;
 	private final JwtService jwtService;
 	private final UserRepository userRepository;
+	private final PasswordEncoder encoder;
+	private final S3Uploader s3Uploader;
 
 	public ApiResponse<String> logout(LogoutRequestDto dto, CustomUserDetails userDetails) {
 		String accessToken = dto.getAccessToken();
@@ -59,5 +66,41 @@ public class UserService {
 				.major(user.getMajor())
 				.introduction(user.getIntroduction())
 				.build());
+	}
+
+	@Transactional
+	public ApiResponse<Void> modifyUserInfo(UserModifyRequestDto dto, MultipartFile imageFile, String email) {
+		Optional<User> optionalUser = userRepository.findByEmail(email);
+		if (optionalUser.isEmpty()) {
+			return ApiResponse.withError(ErrorCode.NOT_FOUND);
+		}
+		User user = optionalUser.get();
+		if (!encoder.matches(dto.getOriginPassword(), user.getPassword())) {
+			return ApiResponse.withError(ErrorCode.UNAUTHORIZED);
+		}
+
+		String updatedPassword = dto.getUpdatePassword();
+		if (!StringUtils.isBlank(updatedPassword)) {
+			user.updatePassword(encoder.encode(updatedPassword));
+		}
+
+		String updatedIntroduction = dto.getIntroduction();
+		if (!StringUtils.isBlank(updatedIntroduction)) {
+			user.updateIntroduction(updatedIntroduction);
+		}
+
+		String profileImageUrl = uploadImage(imageFile).getData();
+		if (profileImageUrl != null) {
+			user.updateUserProfile(profileImageUrl);
+		}
+		user.updateUser(dto);
+		return ApiResponse.ok("회원 정보 수정 완료");
+	}
+
+	private ApiResponse<String> uploadImage(MultipartFile multipartFile) {
+		if (multipartFile == null) {
+			return ApiResponse.ok("이미지가 없습니다", null);
+		}
+		return s3Uploader.uploadFile(multipartFile);
 	}
 }

--- a/src/main/java/mju/sw/micro/domain/user/application/UserService.java
+++ b/src/main/java/mju/sw/micro/domain/user/application/UserService.java
@@ -39,7 +39,7 @@ public class UserService {
 	private final S3Uploader s3Uploader;
 	private final MailService mailService;
 
-	public ApiResponse<String> logout(LogoutRequestDto dto, CustomUserDetails userDetails) {
+	public ApiResponse<Void> logout(LogoutRequestDto dto, CustomUserDetails userDetails) {
 		String accessToken = dto.getAccessToken();
 		if (!jwtService.isTokenValid(accessToken)) {
 			return ApiResponse.withError(ErrorCode.INVALID_TOKEN);

--- a/src/main/java/mju/sw/micro/domain/user/domain/User.java
+++ b/src/main/java/mju/sw/micro/domain/user/domain/User.java
@@ -17,6 +17,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import mju.sw.micro.domain.BaseEntity;
+import mju.sw.micro.domain.user.dto.request.UserModifyRequestDto;
 
 @Entity
 @Table(name = "users")
@@ -48,8 +49,8 @@ public class User extends BaseEntity {
 	private boolean notification;
 
 	@Builder
-	public User(String name, String email, String phoneNumber, String introduction, String nickName,
-		String studentId, String major, String password, boolean notification, String profileImageUrl) {
+	public User(String name, String email, String phoneNumber, String introduction, String nickName, String studentId,
+		String major, String password, boolean notification, String profileImageUrl) {
 		this.email = email;
 		this.password = password;
 		this.name = name;
@@ -62,8 +63,8 @@ public class User extends BaseEntity {
 		this.profileImageUrl = profileImageUrl;
 	}
 
-	public static User createUser(String name, String email, String phoneNumber, String introduction,
-		String nickName, String studentId, String major, String password, boolean notification) {
+	public static User createUser(String name, String email, String phoneNumber, String introduction, String nickName,
+		String studentId, String major, String password, boolean notification) {
 		return User.builder()
 			.name(name)
 			.email(email)
@@ -82,5 +83,24 @@ public class User extends BaseEntity {
 		UserRole userRole = new UserRole();
 		userRole.associate(this, role);
 		userRoles.add(userRole);
+	}
+
+	public void updatePassword(String password) {
+		this.password = password;
+	}
+
+	public void updateUserProfile(String profileImageUrl) {
+		this.profileImageUrl = profileImageUrl;
+	}
+
+	public void updateUser(UserModifyRequestDto dto) {
+		this.phoneNumber = dto.getPhoneNumber();
+		this.name = dto.getName();
+		this.nickName = dto.getNickName();
+		this.major = dto.getMajor();
+	}
+
+	public void updateIntroduction(String updatedIntroduction) {
+		this.introduction = updatedIntroduction;
 	}
 }

--- a/src/main/java/mju/sw/micro/domain/user/domain/User.java
+++ b/src/main/java/mju/sw/micro/domain/user/domain/User.java
@@ -40,45 +40,41 @@ public class User extends BaseEntity {
 	@Column(nullable = false)
 	private String password;
 	@Column(nullable = false)
-	private String interest;
-	@Column(nullable = false)
 	private String major;
 	@OneToMany(mappedBy = "user", fetch = FetchType.EAGER, orphanRemoval = true, cascade = CascadeType.ALL)
 	private List<UserRole> userRoles = new ArrayList<>();
 	private String introduction;
-	private String imageUrl;
+	private String profileImageUrl;
 	private boolean notification;
 
 	@Builder
-	public User(String name, String email, String phoneNumber, String interest, String introduction, String nickName,
-		String studentId, String major, String password, boolean notification, String imageUrl) {
+	public User(String name, String email, String phoneNumber, String introduction, String nickName,
+		String studentId, String major, String password, boolean notification, String profileImageUrl) {
 		this.email = email;
 		this.password = password;
 		this.name = name;
 		this.nickName = nickName;
 		this.studentId = studentId;
 		this.major = major;
-		this.interest = interest;
 		this.phoneNumber = phoneNumber;
 		this.introduction = introduction;
 		this.notification = notification;
-		this.imageUrl = imageUrl;
+		this.profileImageUrl = profileImageUrl;
 	}
 
-	public static User createUser(String name, String email, String phoneNumber, String interest, String introduction,
+	public static User createUser(String name, String email, String phoneNumber, String introduction,
 		String nickName, String studentId, String major, String password, boolean notification) {
 		return User.builder()
 			.name(name)
 			.email(email)
 			.phoneNumber(phoneNumber)
-			.interest(interest)
 			.introduction(introduction)
 			.nickName(nickName)
 			.studentId(studentId)
 			.major(major)
 			.password(password)
 			.notification(notification)
-			//			.imageUrl(null)
+			.profileImageUrl(null)
 			.build();
 	}
 

--- a/src/main/java/mju/sw/micro/domain/user/dto/request/SignUpRequestDto.java
+++ b/src/main/java/mju/sw/micro/domain/user/dto/request/SignUpRequestDto.java
@@ -23,8 +23,6 @@ public class SignUpRequestDto {
 	@NotBlank
 	private String major;
 	@NotBlank
-	private String interest;
-	@NotBlank
 	private String phoneNumber;
 	private String introduction;
 	private Boolean notification;
@@ -32,7 +30,7 @@ public class SignUpRequestDto {
 	String code;
 
 	public static SignUpRequestDto of(String email, String password, String name, String nickName, String studentId,
-		String major, String interest, String phoneNumber, String introduction,
+		String major, String phoneNumber, String introduction,
 		Boolean notification, String code) {
 		SignUpRequestDto dto = new SignUpRequestDto();
 		dto.email = email;
@@ -41,7 +39,6 @@ public class SignUpRequestDto {
 		dto.nickName = nickName;
 		dto.studentId = studentId;
 		dto.major = major;
-		dto.interest = interest;
 		dto.phoneNumber = phoneNumber;
 		dto.introduction = introduction;
 		dto.notification = notification;

--- a/src/main/java/mju/sw/micro/domain/user/dto/request/UserModifyRequestDto.java
+++ b/src/main/java/mju/sw/micro/domain/user/dto/request/UserModifyRequestDto.java
@@ -1,0 +1,22 @@
+package mju.sw.micro.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserModifyRequestDto {
+	@NotBlank
+	private String originPassword;
+	private String updatePassword;
+	@NotBlank
+	private String phoneNumber;
+	@NotBlank
+	private String name;
+	@NotBlank
+	private String nickName;
+	@NotBlank
+	private String major;
+	private String introduction;
+}

--- a/src/main/java/mju/sw/micro/domain/user/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/mju/sw/micro/domain/user/dto/response/UserInfoResponseDto.java
@@ -1,0 +1,17 @@
+package mju.sw.micro.domain.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserInfoResponseDto {
+	private String profileImageUrl;
+	private String name;
+	private String nickName;
+	private String major;
+	private String introduction;
+}
+
+
+

--- a/src/main/java/mju/sw/micro/global/adapter/MailService.java
+++ b/src/main/java/mju/sw/micro/global/adapter/MailService.java
@@ -1,46 +1,6 @@
 package mju.sw.micro.global.adapter;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.stereotype.Component;
+public interface MailService {
 
-import jakarta.mail.Message.RecipientType;
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.InternetAddress;
-import jakarta.mail.internet.MimeMessage;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import mju.sw.micro.global.common.response.ApiResponse;
-import mju.sw.micro.global.error.exception.ErrorCode;
-
-@Slf4j
-@Component
-@RequiredArgsConstructor
-public class MailService {
-
-	@Value("${spring.mail.username}")
-	private String senderEmail;
-	private final JavaMailSender emailSender;
-
-	public void sendMessage(String recipientEmail, String title, String content, String extra) {
-		ApiResponse<MimeMessage> message = createMessage(recipientEmail, title, content, extra);
-		emailSender.send(message.getData());
-	}
-
-	private ApiResponse<MimeMessage> createMessage(String recipientEmail, String title, String content,
-		String extra) {
-		MimeMessage message = emailSender.createMimeMessage();
-		try {
-			String contents = String.format(content, extra);
-			message.addRecipients(RecipientType.TO, recipientEmail); //받는 사람
-			message.setSubject(title); //제목
-			message.setText(contents, "UTF-8", "html"); //내용
-			message.setFrom(new InternetAddress(senderEmail)); //보내는 사람
-			return ApiResponse.ok(message);
-		} catch (MessagingException e) {
-			log.info("fail");
-			return ApiResponse.withError(ErrorCode.BAD_REQUEST);
-		}
-	}
-
+	void sendMessage(String recipientEmail, String title, String content, String extra);
 }

--- a/src/main/java/mju/sw/micro/global/adapter/MailServiceImpl.java
+++ b/src/main/java/mju/sw/micro/global/adapter/MailServiceImpl.java
@@ -1,0 +1,47 @@
+package mju.sw.micro.global.adapter;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+import jakarta.mail.Message.RecipientType;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import mju.sw.micro.global.common.response.ApiResponse;
+import mju.sw.micro.global.error.exception.ErrorCode;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MailServiceImpl implements MailService {
+
+	@Value("${spring.mail.username}")
+	private String senderEmail;
+	private final JavaMailSender emailSender;
+
+	@Override
+	public void sendMessage(String recipientEmail, String title, String content, String extra) {
+		ApiResponse<MimeMessage> message = createMessage(recipientEmail, title, content, extra);
+		emailSender.send(message.getData());
+	}
+
+	private ApiResponse<MimeMessage> createMessage(String recipientEmail, String title, String content,
+		String extra) {
+		MimeMessage message = emailSender.createMimeMessage();
+		try {
+			String contents = String.format(content, extra);
+			message.addRecipients(RecipientType.TO, recipientEmail); //받는 사람
+			message.setSubject(title); //제목
+			message.setText(contents, "UTF-8", "html"); //내용
+			message.setFrom(new InternetAddress(senderEmail)); //보내는 사람
+			return ApiResponse.ok(message);
+		} catch (MessagingException e) {
+			log.info("fail");
+			return ApiResponse.withError(ErrorCode.BAD_REQUEST);
+		}
+	}
+
+}

--- a/src/main/java/mju/sw/micro/global/config/WebSecurityConfig.java
+++ b/src/main/java/mju/sw/micro/global/config/WebSecurityConfig.java
@@ -6,7 +6,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -54,6 +54,6 @@ public class WebSecurityConfig {
 
 	@Bean
 	public PasswordEncoder passwordEncoder() {
-		return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+		return new BCryptPasswordEncoder();
 	}
 }

--- a/src/main/java/mju/sw/micro/global/config/WebSecurityConfig.java
+++ b/src/main/java/mju/sw/micro/global/config/WebSecurityConfig.java
@@ -19,10 +19,11 @@ import mju.sw.micro.global.security.jwt.JwtAuthenticationFilter;
 import mju.sw.micro.global.security.jwt.JwtExceptionFilter;
 
 @Configuration
-@EnableWebSecurity
+@EnableWebSecurity(debug = true)
 @RequiredArgsConstructor
 public class WebSecurityConfig {
 	private final MicroAccessDeniedHandler accessDeniedHandler;
+
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 	private final JwtExceptionFilter jwtExceptionFilter;
 	private final CorsConfig corsConfig;
@@ -38,7 +39,10 @@ public class WebSecurityConfig {
 			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class)
 			.authorizeHttpRequests(
-				authorizeHttpRequests -> authorizeHttpRequests.requestMatchers(new AntPathRequestMatcher("/"))
+				authorizeHttpRequests -> authorizeHttpRequests
+					.requestMatchers(new AntPathRequestMatcher("/swagger-ui/**"))
+					.permitAll()
+					.requestMatchers(new AntPathRequestMatcher("/v3/api-docs/**"))
 					.permitAll()
 					.requestMatchers(new AntPathRequestMatcher("/api/auth/**"))
 					.anonymous()

--- a/src/main/java/mju/sw/micro/global/constants/EmailConstants.java
+++ b/src/main/java/mju/sw/micro/global/constants/EmailConstants.java
@@ -5,13 +5,14 @@ public final class EmailConstants {
 	}
 
 	public static final String EMAIL_SIGN_UP_TITLE = "Micro Sign-up Verification Code";
-	public static final String EMAIL_SIGN_UP_CONTENT_HTML = "<div>" + "Thank you for signing up for 놀명뭐하니.<br>"
-		+ "Please enter the verification code below to complete the sign-up.<br>" + "CODE : <strong> %s </strong>"
-		+ "<div>";
+	public static final String EMAIL_SIGN_UP_CONTENT_HTML =
+		"<div>" + "Thank you for signing up for <strong> 놀명뭐하니 </strong> <br>"
+			+ "Please enter the verification code below to complete the sign-up.<br>" + "CODE : <strong> %s </strong>"
+			+ "<div>";
 	public static final String EMAIL_WITHDRAWAL_TITLE = "Micro Withdrawal Announcement";
-	public static final String EMAIL_WITHDRAWAL_CONTENT_HTML = "<div>" + "Thank you for using our services.<br>"
-		+ "Your membership withdrawal is complete. <br>" + "Your Withdrawal Email : <strong> %s </strong>"
-		+ "<div>";
+	public static final String EMAIL_WITHDRAWAL_CONTENT_HTML =
+		"<div>" + "Thank you for using our services.<br>" + "Your membership withdrawal is complete. <br>"
+			+ "Your Withdrawal Email : <strong> %s </strong>" + "<div>";
 	public static final Long EMAIL_TOKEN_EXPIRATION_TIME = 60 * 5L * 1000;
 
 }

--- a/src/main/java/mju/sw/micro/global/constants/EmailConstants.java
+++ b/src/main/java/mju/sw/micro/global/constants/EmailConstants.java
@@ -4,9 +4,13 @@ public final class EmailConstants {
 	private EmailConstants() {
 	}
 
-	public static final String EMAIL_TITLE = "Micro Sign-up Verification Code";
-	public static final String EMAIL_CONTENT_HTML = "<div>" + "Thank you for signing up for Micro.<br>"
+	public static final String EMAIL_SIGN_UP_TITLE = "Micro Sign-up Verification Code";
+	public static final String EMAIL_SIGN_UP_CONTENT_HTML = "<div>" + "Thank you for signing up for 놀명뭐하니.<br>"
 		+ "Please enter the verification code below to complete the sign-up.<br>" + "CODE : <strong> %s </strong>"
+		+ "<div>";
+	public static final String EMAIL_WITHDRAWAL_TITLE = "Micro Withdrawal Announcement";
+	public static final String EMAIL_WITHDRAWAL_CONTENT_HTML = "<div>" + "Thank you for using our services.<br>"
+		+ "Your membership withdrawal is complete. <br>" + "Your Withdrawal Email : <strong> %s </strong>"
 		+ "<div>";
 	public static final Long EMAIL_TOKEN_EXPIRATION_TIME = 60 * 5L * 1000;
 

--- a/src/main/java/mju/sw/micro/global/security/CustomUserDetails.java
+++ b/src/main/java/mju/sw/micro/global/security/CustomUserDetails.java
@@ -35,11 +35,6 @@ public record CustomUserDetails(User user) implements UserDetails, MicroUserDeta
 	}
 
 	@Override
-	public String getInterest() {
-		return user.getInterest();
-	}
-
-	@Override
 	public String getIntroduction() {
 		return user.getIntroduction();
 	}
@@ -79,6 +74,8 @@ public record CustomUserDetails(User user) implements UserDetails, MicroUserDeta
 		return true;
 	}
 
-	public Long getUserId() {return user.getId();}
+	public Long getUserId() {
+		return user.getId();
+	}
 
 }

--- a/src/main/java/mju/sw/micro/global/security/MicroUserDetails.java
+++ b/src/main/java/mju/sw/micro/global/security/MicroUserDetails.java
@@ -9,8 +9,6 @@ public interface MicroUserDetails extends Serializable {
 
 	String getNickName();
 
-	String getInterest();
-
 	String getIntroduction();
 
 	String getPhoneNumber();

--- a/src/test/java/mju/sw/micro/IntegrationTestSupporter.java
+++ b/src/test/java/mju/sw/micro/IntegrationTestSupporter.java
@@ -9,6 +9,7 @@ import mju.sw.micro.domain.club.application.ClubRecruitmentService;
 import mju.sw.micro.domain.club.dao.ClubRecruitmentRepository;
 import mju.sw.micro.domain.club.dao.ClubRepository;
 import mju.sw.micro.domain.user.application.AuthService;
+import mju.sw.micro.domain.user.application.UserService;
 import mju.sw.micro.domain.user.dao.EmailCodeRedisRepository;
 import mju.sw.micro.domain.user.dao.UserRepository;
 
@@ -29,6 +30,8 @@ public abstract class IntegrationTestSupporter {
 	protected ClubRecruitmentRepository recruitmentRepository;
 	@Autowired
 	protected UserRepository userRepository;
+	@Autowired
+	protected UserService userService;
 	@Autowired
 	protected AuthService authService;
 	@Autowired

--- a/src/test/java/mju/sw/micro/IntegrationTestSupporter.java
+++ b/src/test/java/mju/sw/micro/IntegrationTestSupporter.java
@@ -2,6 +2,7 @@ package mju.sw.micro;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
 import mju.sw.micro.domain.club.application.ClubRecruitmentDeleteService;
@@ -36,5 +37,7 @@ public abstract class IntegrationTestSupporter {
 	protected AuthService authService;
 	@Autowired
 	protected EmailCodeRedisRepository emailCodeRedisRepository;
+	@Autowired
+	protected PasswordEncoder encoder;
 
 }

--- a/src/test/java/mju/sw/micro/IntegrationTestSupporter.java
+++ b/src/test/java/mju/sw/micro/IntegrationTestSupporter.java
@@ -2,6 +2,7 @@ package mju.sw.micro;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -13,6 +14,7 @@ import mju.sw.micro.domain.user.application.AuthService;
 import mju.sw.micro.domain.user.application.UserService;
 import mju.sw.micro.domain.user.dao.EmailCodeRedisRepository;
 import mju.sw.micro.domain.user.dao.UserRepository;
+import mju.sw.micro.global.adapter.MailService;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -39,5 +41,7 @@ public abstract class IntegrationTestSupporter {
 	protected EmailCodeRedisRepository emailCodeRedisRepository;
 	@Autowired
 	protected PasswordEncoder encoder;
+	@MockBean
+	protected MailService mailService;
 
 }

--- a/src/test/java/mju/sw/micro/domain/user/application/AuthServiceTest.java
+++ b/src/test/java/mju/sw/micro/domain/user/application/AuthServiceTest.java
@@ -36,7 +36,7 @@ class AuthServiceTest extends IntegrationTestSupporter {
 	}
 
 	@AfterEach
-	void deleteUser() {
+	void tearDown() {
 		userRepository.deleteAll();
 	}
 
@@ -49,7 +49,7 @@ class AuthServiceTest extends IntegrationTestSupporter {
 	// 		TimeUtil.generateExpiration(MockConstants.MOCK_TOKEN_EXPIRATION_TIME));
 	// 	emailCodeRedisRepository.save(emailCode);
 	// 	// when
-	// 	ApiResponse<String> response = authService.signUp(signUpRequestDto);
+	// 	ApiResponse<String> response = authService.signUp(signUpRequestDto, null);
 	// 	Optional<User> optionalUser = userRepository.findByEmail(MockConstants.MOCK_USER_EMAIL);
 	// 	Assertions.assertTrue(optionalUser.isPresent(), "회원가입에 실패했습니다.");
 	// 	User user = optionalUser.get();

--- a/src/test/java/mju/sw/micro/domain/user/application/AuthServiceTest.java
+++ b/src/test/java/mju/sw/micro/domain/user/application/AuthServiceTest.java
@@ -68,7 +68,7 @@ class AuthServiceTest extends IntegrationTestSupporter {
 		User user = MockFactory.createMockUser();
 		userRepository.save(user);
 		// when
-		ApiResponse<String> response = authService.signUp(signUpRequestDto, null);
+		ApiResponse<Void> response = authService.signUp(signUpRequestDto, null);
 		// then
 		Assertions.assertEquals("이미 가입된 이메일 입니다.", response.getMessage());
 	}
@@ -86,7 +86,7 @@ class AuthServiceTest extends IntegrationTestSupporter {
 			MockConstants.MOCK_MAJOR, MockConstants.MOCK_PHONE_NUMBER,
 			MockConstants.MOCK_INTRODUCTION, false, "wrongCode");
 		// when
-		ApiResponse<String> response = authService.signUp(dto, null);
+		ApiResponse<Void> response = authService.signUp(dto, null);
 		// then
 		Assertions.assertEquals("인증 토큰이 유효하지 않습니다.", response.getMessage());
 	}

--- a/src/test/java/mju/sw/micro/domain/user/application/AuthServiceTest.java
+++ b/src/test/java/mju/sw/micro/domain/user/application/AuthServiceTest.java
@@ -31,7 +31,7 @@ class AuthServiceTest extends IntegrationTestSupporter {
 		verificationCode = CodeUtil.generateRandomCode();
 		signUpRequestDto = SignUpRequestDto.of(MockConstants.MOCK_USER_EMAIL, MockConstants.MOCK_USER_PASSWORD,
 			MockConstants.MOCK_USER_NAME, MockConstants.MOCK_USER_NICKNAME, MockConstants.MOCK_STUDENT_ID,
-			MockConstants.MOCK_MAJOR, MockConstants.MOCK_INTEREST, MockConstants.MOCK_PHONE_NUMBER,
+			MockConstants.MOCK_MAJOR, MockConstants.MOCK_PHONE_NUMBER,
 			MockConstants.MOCK_INTRODUCTION, false, verificationCode);
 	}
 
@@ -83,7 +83,7 @@ class AuthServiceTest extends IntegrationTestSupporter {
 		emailCodeRedisRepository.save(emailCode);
 		SignUpRequestDto dto = SignUpRequestDto.of(MockConstants.MOCK_USER_EMAIL, MockConstants.MOCK_USER_PASSWORD,
 			MockConstants.MOCK_USER_NAME, MockConstants.MOCK_USER_NICKNAME, MockConstants.MOCK_STUDENT_ID,
-			MockConstants.MOCK_MAJOR, MockConstants.MOCK_INTEREST, MockConstants.MOCK_PHONE_NUMBER,
+			MockConstants.MOCK_MAJOR, MockConstants.MOCK_PHONE_NUMBER,
 			MockConstants.MOCK_INTRODUCTION, false, "wrongCode");
 		// when
 		ApiResponse<String> response = authService.signUp(dto, null);

--- a/src/test/java/mju/sw/micro/domain/user/application/UserServiceTest.java
+++ b/src/test/java/mju/sw/micro/domain/user/application/UserServiceTest.java
@@ -1,0 +1,39 @@
+package mju.sw.micro.domain.user.application;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import mju.sw.micro.IntegrationTestSupporter;
+import mju.sw.micro.domain.user.domain.User;
+import mju.sw.micro.domain.user.dto.response.UserInfoResponseDto;
+import mju.sw.micro.global.common.response.ApiResponse;
+import mju.sw.micro.global.utils.MockFactory;
+
+class UserServiceTest extends IntegrationTestSupporter {
+
+	@AfterEach
+	void tearDown() {
+		userRepository.deleteAllInBatch();
+	}
+
+	@DisplayName("회원 정보를 가져온다.")
+	@Test
+	void getUserInfoTest() {
+		// given
+		User user = MockFactory.createMockUser();
+		userRepository.save(user);
+		//when
+		ApiResponse<UserInfoResponseDto> userResponse = userService.getUserInfo(user.getEmail());
+		// then
+		UserInfoResponseDto userInfoResponseDto = userResponse.getData();
+
+		Assertions.assertNull(user.getProfileImageUrl(), userInfoResponseDto.getProfileImageUrl());
+		Assertions.assertEquals(user.getName(), userInfoResponseDto.getName());
+		Assertions.assertEquals(user.getNickName(), userInfoResponseDto.getNickName());
+		Assertions.assertEquals(user.getMajor(), userInfoResponseDto.getMajor());
+		Assertions.assertEquals(user.getIntroduction(), userInfoResponseDto.getIntroduction());
+
+	}
+}

--- a/src/test/java/mju/sw/micro/domain/user/application/UserServiceTest.java
+++ b/src/test/java/mju/sw/micro/domain/user/application/UserServiceTest.java
@@ -1,5 +1,7 @@
 package mju.sw.micro.domain.user.application;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -117,5 +119,33 @@ class UserServiceTest extends IntegrationTestSupporter {
 		// then
 		Assertions.assertEquals(HttpStatus.UNAUTHORIZED, userResponse.getStatus());
 		Assertions.assertEquals("인증이 필요한 접근입니다.", userResponse.getMessage());
+	}
+
+	@DisplayName("회원 탈퇴를 한다.")
+	@Test
+	void deleteUser() {
+		// given
+		User user = MockFactory.createMockUser();
+		userRepository.save(user);
+		//when
+		ApiResponse<Void> userResponse = userService.deleteUser(user.getEmail());
+		Optional<User> optionalUser = userRepository.findByEmail(user.getEmail());
+		// then
+		Assertions.assertEquals(HttpStatus.OK, userResponse.getStatus());
+		Assertions.assertEquals("회원 탈퇴 완료", userResponse.getMessage());
+		Assertions.assertTrue(optionalUser.isEmpty());
+	}
+
+	@DisplayName("잘못된 이메일을 입력하여 회원 탈퇴를 실패한다.")
+	@Test
+	void deleteUserWithInvalidEmail() {
+		// given
+		User user = MockFactory.createMockUser();
+		userRepository.save(user);
+		//when
+		ApiResponse<Void> userResponse = userService.deleteUser("invalidEmail");
+		// then
+		Assertions.assertEquals(HttpStatus.NOT_FOUND, userResponse.getStatus());
+		Assertions.assertEquals("요청한 리소스를 찾을 수 없습니다.", userResponse.getMessage());
 	}
 }

--- a/src/test/java/mju/sw/micro/global/security/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/mju/sw/micro/global/security/WithMockCustomUserSecurityContextFactory.java
@@ -6,10 +6,8 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
 
-import lombok.extern.slf4j.Slf4j;
 import mju.sw.micro.domain.user.domain.User;
 
-@Slf4j
 public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
 	@Override
 	public SecurityContext createSecurityContext(WithMockCustomUser customUser) {

--- a/src/test/java/mju/sw/micro/global/security/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/mju/sw/micro/global/security/WithMockCustomUserSecurityContextFactory.java
@@ -23,7 +23,6 @@ public class WithMockCustomUserSecurityContextFactory implements WithSecurityCon
 			.studentId(customUser.studentId())
 			.nickName(customUser.nickName())
 			.introduction(customUser.introduction())
-			.interest(customUser.interest())
 			.password(customUser.password())
 			.build();
 		user.addRole(customUser.role());

--- a/src/test/java/mju/sw/micro/global/utils/MockFactory.java
+++ b/src/test/java/mju/sw/micro/global/utils/MockFactory.java
@@ -7,7 +7,7 @@ import mju.sw.micro.domain.user.domain.User;
 public class MockFactory {
 	public static User createMockUser() {
 		return User.createUser(MOCK_USER_NAME, MOCK_USER_EMAIL, MOCK_PHONE_NUMBER,
-			MOCK_INTEREST, MOCK_INTRODUCTION, MOCK_USER_NICKNAME, MOCK_STUDENT_ID, MOCK_MAJOR,
+			MOCK_INTRODUCTION, MOCK_USER_NICKNAME, MOCK_STUDENT_ID, MOCK_MAJOR,
 			MOCK_USER_PASSWORD, false);
 	}
 }


### PR DESCRIPTION
### 기능
- 회원 정보 조회 기능 추가
- 회원 정보 수정 기능 추가
- 회원 삭제 기능 추가


### 이슈
- 회원 정보 조회의 경우  관심 있는 단체, 참여 중인 단체 조회는 추후에 기능 추가되면 다시 수정 예정
- 회원 수정의 경우 정확한 디자인이 나오지 않아 로직 수정이 필요할 수 있음
- User가 가지는 속성 중 관심 종목(interest) 삭제, 추천 기능이 사라져서 삭제함

### 테스트
- 테스트 코드 결과
![image](https://github.com/MJU-MICRO/MICRO_Server/assets/55132026/474f6a66-01aa-4856-bcf1-7e9ad2818251)
- 포스트맨
  - 회원 정보 조회
   ![image](https://github.com/MJU-MICRO/MICRO_Server/assets/55132026/339f84eb-1588-40d0-8ec2-f417d40cf5f9)
  - 회원 정보 수정
    ![image](https://github.com/MJU-MICRO/MICRO_Server/assets/55132026/e288ab7f-03bb-4f69-9265-cde7e725caab)
  - 회원 탈퇴
   ![image](https://github.com/MJU-MICRO/MICRO_Server/assets/55132026/46d290af-3a01-45ac-8e2f-088c0802cafc)



