### PR TITLE
[회장] 신청서, 단체, 모집 공고 조회 기능 추가

### DIFF
--- a/src/main/java/mju/sw/micro/domain/application/api/ApplicationApi.java
+++ b/src/main/java/mju/sw/micro/domain/application/api/ApplicationApi.java
@@ -85,7 +85,7 @@ public class ApplicationApi {
 	@Operation(summary = "회장이 확인할 신청서 리스트 조회")
 	@GetMapping("/president/application/list")
 	public ApiResponse<List<ApplicationResponseDto>> getPresidentApplications(@RequestParam Long recruitmentId,
-		@AuthenticationPrincipal CustomUserDetails userDetails) {
-		return applicationService.getPresidentApplications(userDetails, recruitmentId);
+		@RequestParam Long groupId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+		return applicationService.getPresidentApplications(userDetails, recruitmentId, groupId);
 	}
 }

--- a/src/main/java/mju/sw/micro/domain/group/api/StudentGroupApi.java
+++ b/src/main/java/mju/sw/micro/domain/group/api/StudentGroupApi.java
@@ -66,6 +66,13 @@ public class StudentGroupApi {
 		return studentGroupService.approveGroup(groupId);
 	}
 
+	@Operation(summary = "회장 단체 조회")
+	@GetMapping("/president/group")
+	public ApiResponse<List<GroupSimpleResponseDto>> getGroupInfoByPresident(
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		return studentGroupService.getGroupInfoByPresident(userDetails);
+	}
+
 	@Operation(summary = "학생단체 삭제")
 	@DeleteMapping("/president/group/{groupId}")
 	public ApiResponse<String> deleteGroup(@AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/mju/sw/micro/domain/group/application/StudentGroupService.java
+++ b/src/main/java/mju/sw/micro/domain/group/application/StudentGroupService.java
@@ -102,6 +102,15 @@ public class StudentGroupService {
 		return ApiResponse.ok("승인된 학생단체 리스트를 가져왔습니다", approvedGroupInfoList);
 	}
 
+	public ApiResponse<List<GroupSimpleResponseDto>> getGroupInfoByPresident(CustomUserDetails userDetails) {
+		List<StudentGroup> groups = studentGroupDao.findAllByPresidentId(userDetails.getUserId());
+		List<GroupSimpleResponseDto> presidentGroupInfoList = groups.stream()
+			.filter(StudentGroup::isApprove)
+			.map(this::mapToGroupSimpleResponseDto)
+			.toList();
+		return ApiResponse.ok("회장 학생단체 리스트를 가져왔습니다", presidentGroupInfoList);
+	}
+
 	public ApiResponse<String> updateGroupInfo(Long groupId, StudentGroupRequestDto dto, CustomUserDetails userDetails,
 		MultipartFile imageFile) {
 		Optional<StudentGroup> optionalGroup = studentGroupDao.findById(groupId);
@@ -273,4 +282,5 @@ public class StudentGroupService {
 		responseDto.setSubCategory(group.getSubCategory());
 		return responseDto;
 	}
+
 }

--- a/src/main/java/mju/sw/micro/domain/group/dao/StudentGroupRepository.java
+++ b/src/main/java/mju/sw/micro/domain/group/dao/StudentGroupRepository.java
@@ -1,14 +1,13 @@
 package mju.sw.micro.domain.group.dao;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import mju.sw.micro.domain.group.domain.StudentGroup;
 
 public interface StudentGroupRepository extends JpaRepository<StudentGroup, Long> {
-	Optional<StudentGroup> findByPresidentId(Long userId);
+	List<StudentGroup> findAllByPresidentId(Long userId);
 
 	List<StudentGroup> findByIsRecruitTrue();
 }

--- a/src/main/java/mju/sw/micro/domain/recruitment/api/GroupRecruitmentRetrieveApi.java
+++ b/src/main/java/mju/sw/micro/domain/recruitment/api/GroupRecruitmentRetrieveApi.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,6 +29,13 @@ public class GroupRecruitmentRetrieveApi {
 		<List<SimpleGroupRecruitmentResponse>> retrieveAllRecruitments() {
 		return ApiResponse.ok("학생 단체(동아리/학회) 공고 전체 목록 조회에 성공했습니다.",
 			groupRecruitmentRetrieveService.retrieveAllRecruitments());
+	}
+
+	@Operation(summary = "회장 모집 공고 목록 조회 ")
+	@GetMapping("/api/president/recruitment")
+	public ApiResponse<List<GroupRecruitmentResponse>> retrieveAllRecruitmentsByPresident(@RequestParam Long groupId) {
+		return ApiResponse.ok("회장 공고 전체 목록 조회에 성공했습니다.",
+			groupRecruitmentRetrieveService.retrieveAllRecruitmentsByPresident(groupId));
 	}
 
 	@Operation(summary = "특정 동아리 / 학회 모집 공고 상세 조회 요청")

--- a/src/main/java/mju/sw/micro/domain/recruitment/application/GroupRecruitmentRetrieveService.java
+++ b/src/main/java/mju/sw/micro/domain/recruitment/application/GroupRecruitmentRetrieveService.java
@@ -39,6 +39,15 @@ public class GroupRecruitmentRetrieveService {
 		return response;
 	}
 
+	public List<GroupRecruitmentResponse> retrieveAllRecruitmentsByPresident(Long groupId) {
+		List<GroupRecruitment> recruitmentList = recruitmentRepository.findByGroupId(groupId);
+		List<GroupRecruitmentResponse> response = new ArrayList<>();
+		for (GroupRecruitment recruitment : recruitmentList) {
+			response.add(GroupRecruitmentResponse.of(recruitment));
+		}
+		return response;
+	}
+
 	public GroupRecruitmentResponse retrieveRecruitment(Long recruitmentId) {
 		GroupRecruitment recruitment = recruitmentRepository.findById(recruitmentId)
 			.orElseThrow(() -> new NotFoundException("Recruitment not found with id: " + recruitmentId));
@@ -57,4 +66,5 @@ public class GroupRecruitmentRetrieveService {
 		}
 		return response;
 	}
+
 }

--- a/src/main/java/mju/sw/micro/domain/recruitment/dao/GroupRecruitmentRepository.java
+++ b/src/main/java/mju/sw/micro/domain/recruitment/dao/GroupRecruitmentRepository.java
@@ -4,11 +4,10 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import mju.sw.micro.domain.group.domain.StudentGroup;
 import mju.sw.micro.domain.recruitment.domain.GroupRecruitment;
 
 public interface GroupRecruitmentRepository extends JpaRepository<GroupRecruitment, Long> {
-	List<GroupRecruitment> findByGroup(StudentGroup group);
+	List<GroupRecruitment> findByGroupId(Long groupId);
 
 	List<GroupRecruitment> findAllByOrderByCreatedDateTimeDesc();
 }

--- a/src/main/java/mju/sw/micro/domain/user/domain/User.java
+++ b/src/main/java/mju/sw/micro/domain/user/domain/User.java
@@ -86,9 +86,21 @@ public class User extends BaseEntity {
 	}
 
 	public void addRole(Role role) {
+		if (validateRole(role))
+			return;
+
 		UserRole userRole = new UserRole();
 		userRole.associate(this, role);
 		userRoles.add(userRole);
+	}
+
+	private boolean validateRole(Role role) {
+		for (UserRole userRole : userRoles) {
+			if (userRole.getRole().equals(role)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public void addApplication(Application application) {


### PR DESCRIPTION
- 회장 권한 위임 시 기존의 회장이었던 사용자가 있다면 또 다른 단체의 회장이 된다면 권한 중복 , 관련해서 예외 처리
- 회장 신청서 조회 로직 수정
- 회장 단체 리스트 조회 기능 추가
- 회장 모집 공고 리스트 조회 기능 추가